### PR TITLE
左上角 el-icon-menu 改成 el-icon-s-fold 和 el-icon-s-unfold

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -2,7 +2,8 @@
     <div class="header">
         <!-- 折叠按钮 -->
         <div class="collapse-btn" @click="collapseChage">
-            <i class="el-icon-menu"></i>
+             <i v-if="!collapse" class="el-icon-s-fold"></i>
+             <i v-if="collapse" class="el-icon-s-unfold"></i>
         </div>
         <div class="logo">后台管理系统</div>
         <div class="header-right">


### PR DESCRIPTION
#196 

<img width="508" alt="Screen Shot 2019-08-15 at 2 18 12 PM" src="https://user-images.githubusercontent.com/666683/63076433-dce45900-bf67-11e9-9d4f-825439878da1.png">
<img width="616" alt="Screen Shot 2019-08-15 at 2 18 03 PM" src="https://user-images.githubusercontent.com/666683/63076434-dce45900-bf67-11e9-9ded-6d794729f243.png">
