### PR TITLE
The import should be "wangeditor" instead of "wangEditor"

### DIFF
--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import WangEditor from "wangEditor";
+import WangEditor from "wangeditor";
 import { ref, reactive, onMounted, onBeforeUnmount } from "vue";
 export default {
     name: "editor",


### PR DESCRIPTION
error when starting dev server:
```
Error: The following dependencies are imported but could not be resolved:

  wangEditor (imported by /home/zfn/vue-manage-system/src/views/Editor.vue)

Are they installed?
```