### PR TITLE
chore: 路由守卫vue2 -> vue3

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -271,18 +271,18 @@ const router = createRouter({
     routes,
 });
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to) => {
     NProgress.start();
     const role = localStorage.getItem('vuems_name');
     const permiss = usePermissStore();
 
     if (!role && to.meta.noAuth !== true) {
-        next('/login');
+        return '/login';
     } else if (typeof to.meta.permiss == 'string' && !permiss.key.includes(to.meta.permiss)) {
         // 如果没有权限，则进入403
-        next('/403');
+        return '/403';
     } else {
-        next();
+        return;
     }
 });
 


### PR DESCRIPTION
> 和 Vue 2 不同，Vue 2 的 beforeEach 是默认三个参数，第三个参数是 next，用来操作路由接下来的跳转。

但在新版本路由里，已经通过 RFC 将其删除，虽然目前还是作为可选参数使用，但以后不确定是否会移除，不建议继续使用，[点击查看原因](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0037-router-return-guards.md#motivation)。

新版本路由可以通过 return 来代替 next。

文档： https://github.com/vuejs/rfcs/blob/master/active-rfcs/0037-router-return-guards.md#motivation  